### PR TITLE
Add autobuild, analysis and uploading of built artifact using GitHub Actions

### DIFF
--- a/.github/workflows/codeql-autobuild-and-analysis.yml
+++ b/.github/workflows/codeql-autobuild-and-analysis.yml
@@ -1,0 +1,30 @@
+name: CodeQL Autobuild & Analysis
+
+on:
+  push:
+
+jobs:
+  AutobuildAndAnalyze:
+    runs-on: windows-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+
+      - name: Perform CodeQL autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2
+
+      - name: Upload application artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: TOTK-SaveGame-Editor
+          path: TOTK-SaveGame-Editor/bin/Debug/TOTK-SaveGame-Editor.exe

--- a/TOTK-SaveGame-Editor/TOTK-SaveGame-Editor.csproj
+++ b/TOTK-SaveGame-Editor/TOTK-SaveGame-Editor.csproj
@@ -51,18 +51,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>908C8A1D2C507FDDA2AFC7BF26AF074E597988A0</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>TOTK-SaveGame-Editor_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignManifests>true</SignManifests>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This adds automated building and code security vulnerability analysis as well as uploading the executable to GitHub Actions as build artifact.

See here for an example of a run:
https://github.com/hummeltech/TOTK-SaveGame-Editor/actions/runs/5034843949